### PR TITLE
go.bbclass: Adjust dependencies for native

### DIFF
--- a/classes/go.bbclass
+++ b/classes/go.bbclass
@@ -18,7 +18,8 @@ export GOSRC_FINAL = "${GOROOT_FINAL}/src"
 export GO_GCFLAGS = "${HOST_CFLAGS}"
 export GO_LDFLAGS = "${HOST_LDFLAGS}"
 
-DEPENDS += "go-cross"
+DEPENDS_class-target += "go-cross"
+DEPENDS_class-native += "go-native"
 
 INHIBIT_PACKAGE_STRIP = "1"
 


### PR DESCRIPTION
Add a dependency on go-native for native and go-cross for target.
This avoid the issue of a native recipe that inherits go from
looking for go-cross-native.

I'm not 100% sure this is the right way to fix this. The upstream go-cross recipes don't do this but I can't see why they don't have to.

Signed-off-by: Will Newton <willn@resin.io>